### PR TITLE
Fix support for async items

### DIFF
--- a/src/asgi_sitemaps/_generation.py
+++ b/src/asgi_sitemaps/_generation.py
@@ -1,4 +1,13 @@
-from typing import AsyncIterable, AsyncIterator, Dict, Iterable, Sequence, cast
+import inspect
+from typing import (
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Dict,
+    Iterable,
+    Sequence,
+    cast,
+)
 from urllib.parse import urljoin, urlsplit
 
 from ._models import SCOPE_CTX_VAR, Sitemap
@@ -34,6 +43,10 @@ async def _ensure_async_iterator(items: ItemsTypes[T]) -> AsyncIterator[T]:
     if hasattr(items, "__aiter__"):
         items = cast(AsyncIterable[T], items)
         async for item in items:
+            yield item
+    elif inspect.isawaitable(items):
+        items = cast(Awaitable[Iterable[T]], items)
+        for item in await items:
             yield item
     else:
         items = cast(Iterable[T], items)

--- a/src/asgi_sitemaps/_types.py
+++ b/src/asgi_sitemaps/_types.py
@@ -1,5 +1,5 @@
-from typing import Any, AsyncIterable, Dict, Iterable, TypeVar, Union
+from typing import Any, AsyncIterable, Awaitable, Dict, Iterable, TypeVar, Union
 
 T = TypeVar("T")
-ItemsTypes = Union[Iterable[T], AsyncIterable[T]]
+ItemsTypes = Union[Iterable[T], Awaitable[Iterable[T]], AsyncIterable[T]]
 Scope = Dict[str, Any]


### PR DESCRIPTION
Cleanup for #4 

Eg `async def items() -> list` was not supported yet although it ought to be as per our docs.